### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/jmeridth/jmeridth.github.io/security/code-scanning/2](https://github.com/jmeridth/jmeridth.github.io/security/code-scanning/2)

To fix the problem, add a `permissions` key to the workflow or job definition. Since the workflow's only job is `deploy`, and it uses `actions-gh-pages` to deploy static content, the minimal necessary permissions are likely `contents: write` (to allow pushing to the `gh-pages` branch) and optionally `pages: write` if you're using GitHub Pages. If unsure, start with the minimal permissions required and increase only if some step fails due to insufficient rights. The correct fix is to add a `permissions` block directly under the `deploy` job (line 11) or at the root (above `jobs:`), but adding to the job is most precise. The block should specify the least power needed: for example,

```yaml
permissions:
  contents: write
```

This change involves inserting a new block immediately before `runs-on: ubuntu-latest` in the deploy job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
