### PR TITLE
fix: restore tags page tag cloud and normalize raspberry-pi tags

### DIFF
--- a/content/posts/2018-04-07-raspberry-pi-kubernetes-cluster-part-1.md
+++ b/content/posts/2018-04-07-raspberry-pi-kubernetes-cluster-part-1.md
@@ -4,7 +4,7 @@ title: Raspberry Pi Kubernetes Cluster - Part 1
 date: 2018-04-07 09:01:00 -05:00
 tags:
 - kubernetes
-- raspberry pi
+- raspberry-pi
 layout: post
 ---
 

--- a/content/posts/2018-05-02-raspberry-pi-kubernetes-cluster-part-2.md
+++ b/content/posts/2018-05-02-raspberry-pi-kubernetes-cluster-part-2.md
@@ -4,7 +4,7 @@ title: Raspberry Pi Kubernetes Cluster - Part 2
 date: '2018-05-02 21:13:07'
 tags:
 - kubernetes
-- raspberry pi
+- raspberry-pi
 layout: post
 ---
 

--- a/content/posts/2018-12-24-raspberry-pi-kubernetes-cluster-part-3.md
+++ b/content/posts/2018-12-24-raspberry-pi-kubernetes-cluster-part-3.md
@@ -4,7 +4,7 @@ title: Raspberry Pi Kubernetes Cluster - Part 3
 layout: post
 tags:
 - kubernetes
-- raspberry pi
+- raspberry-pi
 date: '2018-12-24 15:59:23'
 ---
 

--- a/content/posts/2018-12-28-raspberry-pi-kubernetes-cluster-part-4.md
+++ b/content/posts/2018-12-28-raspberry-pi-kubernetes-cluster-part-4.md
@@ -4,7 +4,7 @@ title: Raspberry Pi Kubernetes Cluster - Part 4
 date: '2018-12-28 10:35:23'
 tags:
 - kubernetes
-- raspberrypi
+- raspberry-pi
 layout: post
 ---
 

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -1,3 +1,33 @@
+{{- if eq .Kind "taxonomy" -}}
+<section class="container taxonomy">
+  <header>
+    <h1 class="title">
+      <a class="title-link" href="{{ .Permalink | safeURL }}">
+        {{- i18n (lower .Title) | default .Title | title -}}
+      </a>
+      {{ with .Params.icon }}
+        <i class="{{ . }}" aria-hidden="true"></i>
+      {{ end }}
+    </h1>
+  </header>
+  {{ .Content }}
+  <ul>
+    {{ $type := .Type }}
+    {{ range $key, $value := .Data.Terms.Alphabetical }}
+      {{ $name := .Name }}
+      {{ $count := .Count }}
+      {{ with $.Site.GetPage (printf "/%s/%s" $type $name) }}
+        <li>
+          <span class="taxonomy-element">
+            <a href="{{ .Permalink }}">{{ .Name }}</a>
+            <sup>{{ $count }}</sup>
+          </span>
+        </li>
+      {{ end }}
+    {{ end }}
+  </ul>
+</section>
+{{- else -}}
 <section class="container list">
   <header>
     <h1 class="title">
@@ -24,3 +54,4 @@
   </ul>
   {{ partial "pagination.html" . }}
 </section>
+{{- end -}}


### PR DESCRIPTION
## What

Added taxonomy-specific rendering to the list partial override so taxonomy pages (like /tags/) display as a tag cloud with counts instead of a dated post list. Also consolidated the "raspberry pi", "raspberrypi", and "raspberry pi" tag variants across all four Raspberry Pi Kubernetes Cluster posts into a single "raspberry-pi" tag.

## Why

The hugo-coder theme update merged the taxonomy template into the generic list partial, causing the tags page to render as a post list instead of its original tag cloud format. The inconsistent tag naming also created duplicate tag entries on the tags page.

## Notes

- The list.html partial now branches on `.Kind "taxonomy"` — any future taxonomy pages will also get the tag cloud format rather than the dated list format
- The tag URL will change from `/tags/raspberry-pi/` consolidating what were previously separate pages for each variant