### PR TITLE
feat: add copy-to-clipboard button and line numbers to code blocks

### DIFF
--- a/assets/css/code-blocks.css
+++ b/assets/css/code-blocks.css
@@ -1,0 +1,66 @@
+/* Code block wrapper */
+.highlight {
+  position: relative;
+  border-radius: 0.8rem;
+  margin: 2rem 0;
+}
+
+.highlight > div,
+.highlight > pre {
+  margin: 0;
+  border-radius: 0;
+}
+
+/* Clip top corners via header, allow horizontal scroll on code */
+.highlight > pre,
+.highlight > div > pre {
+  overflow-x: auto;
+}
+
+/* Header bar with language label and copy button */
+.code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 1rem;
+  background-color: #1a1a2e;
+  border-bottom: 1px solid #2a2a3e;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 1.2rem;
+  user-select: none;
+}
+
+.code-lang {
+  color: #8b949e;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.copy-btn {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid #3a3a4e;
+  border-radius: 0.4rem;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 0.2rem 0.8rem;
+  transition: color 0.2s, border-color 0.2s, background-color 0.2s;
+}
+
+.copy-btn:hover {
+  color: #c9d1d9;
+  border-color: #5a5a6e;
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.copy-btn.copied {
+  color: #56d364;
+  border-color: #56d364;
+}
+
+.copy-btn.copy-failed {
+  color: #f85149;
+  border-color: #f85149;
+}

--- a/assets/css/code-blocks.css
+++ b/assets/css/code-blocks.css
@@ -5,7 +5,7 @@
   margin: 2rem 0;
 }
 
-.highlight > div,
+.highlight > div:not(.code-header),
 .highlight > pre {
   margin: 0;
   border-radius: 0;

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,0 +1,144 @@
+(function () {
+  "use strict";
+
+  var LANG_NAMES = {
+    js: "JavaScript",
+    ts: "TypeScript",
+    py: "Python",
+    rb: "Ruby",
+    sh: "Shell",
+    bash: "Bash",
+    zsh: "Zsh",
+    yml: "YAML",
+    yaml: "YAML",
+    json: "JSON",
+    toml: "TOML",
+    xml: "XML",
+    html: "HTML",
+    css: "CSS",
+    scss: "SCSS",
+    sql: "SQL",
+    go: "Go",
+    rs: "Rust",
+    java: "Java",
+    kt: "Kotlin",
+    cs: "C#",
+    cpp: "C++",
+    c: "C",
+    php: "PHP",
+    swift: "Swift",
+    tf: "Terraform",
+    hcl: "HCL",
+    dockerfile: "Dockerfile",
+    makefile: "Makefile",
+    md: "Markdown",
+    plaintext: "Text",
+    text: "Text",
+    txt: "Text",
+  };
+
+  function getLanguage(highlightDiv) {
+    var codeEl = highlightDiv.querySelector("code[data-lang]");
+    if (codeEl) {
+      return codeEl.getAttribute("data-lang");
+    }
+    var fallbackCode = highlightDiv.querySelector("code");
+    var classes = (fallbackCode && fallbackCode.className) || "";
+    var match = classes.match(/language-(\w+)/);
+    return match ? match[1] : "";
+  }
+
+  function displayName(lang) {
+    if (!lang) return "";
+    var lower = lang.toLowerCase();
+    return LANG_NAMES[lower] || lang.charAt(0).toUpperCase() + lang.slice(1);
+  }
+
+  function showButtonState(button, text, className, duration) {
+    button.textContent = text;
+    if (className) button.classList.add(className);
+    setTimeout(function () {
+      button.textContent = "Copy";
+      if (className) button.classList.remove(className);
+    }, duration || 2000);
+  }
+
+  function copyToClipboard(text, button) {
+    if (!navigator.clipboard) {
+      fallbackCopy(text, button);
+      return;
+    }
+    navigator.clipboard.writeText(text).then(
+      function () {
+        showButtonState(button, "Copied!", "copied", 2000);
+      },
+      function () {
+        fallbackCopy(text, button);
+      }
+    );
+  }
+
+  function fallbackCopy(text, button) {
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand("copy");
+      showButtonState(button, "Copied!", "copied", 2000);
+    } catch (e) {
+      showButtonState(button, "Failed", "copy-failed", 2000);
+    }
+    document.body.removeChild(textarea);
+  }
+
+  function init() {
+    var highlights = document.querySelectorAll(".highlight");
+
+    highlights.forEach(function (highlightDiv) {
+      if (highlightDiv.querySelector(".code-header")) return;
+
+      var lang = getLanguage(highlightDiv);
+      var label = displayName(lang);
+
+      var header = document.createElement("div");
+      header.className = "code-header";
+
+      if (label) {
+        var langSpan = document.createElement("span");
+        langSpan.className = "code-lang";
+        langSpan.textContent = label;
+        header.appendChild(langSpan);
+      }
+
+      var copyBtn = document.createElement("button");
+      copyBtn.className = "copy-btn";
+      copyBtn.textContent = "Copy";
+      copyBtn.setAttribute("aria-label", "Copy code to clipboard");
+      copyBtn.addEventListener("click", function () {
+        var codeEl =
+          highlightDiv.querySelector("td:last-child code") ||
+          highlightDiv.querySelector("code");
+        if (codeEl) {
+          var clone = codeEl.cloneNode(true);
+          var lineNums = clone.querySelectorAll(".ln, .lnt");
+          for (var i = 0; i < lineNums.length; i++) {
+            lineNums[i].remove();
+          }
+          copyToClipboard(clone.textContent, copyBtn);
+        }
+      });
+      header.appendChild(copyBtn);
+
+      highlightDiv.insertBefore(header, highlightDiv.firstChild);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -44,7 +44,7 @@
     }
     var fallbackCode = highlightDiv.querySelector("code");
     var classes = (fallbackCode && fallbackCode.className) || "";
-    var match = classes.match(/language-(\w+)/);
+    var match = classes.match(/language-([A-Za-z0-9_-]+)/);
     return match ? match[1] : "";
   }
 
@@ -55,11 +55,15 @@
   }
 
   function showButtonState(button, text, className, duration) {
+    if (button._copyStateTimeoutId) {
+      clearTimeout(button._copyStateTimeoutId);
+    }
     button.textContent = text;
     if (className) button.classList.add(className);
-    setTimeout(function () {
+    button._copyStateTimeoutId = setTimeout(function () {
       button.textContent = "Copy";
       if (className) button.classList.remove(className);
+      button._copyStateTimeoutId = null;
     }, duration || 2000);
   }
 
@@ -116,6 +120,7 @@
       var copyBtn = document.createElement("button");
       copyBtn.className = "copy-btn";
       copyBtn.textContent = "Copy";
+      copyBtn.setAttribute("type", "button");
       copyBtn.setAttribute("aria-label", "Copy code to clipboard");
       copyBtn.addEventListener("click", function () {
         var codeEl =

--- a/hugo.toml
+++ b/hugo.toml
@@ -15,6 +15,8 @@ pagerSize = 20
 
 [markup.highlight]
 noClasses = false
+lineNos = true
+lineNumbersInTable = true
 
 [params]
 author = "Jason Meridth"
@@ -42,12 +44,12 @@ hideColorSchemeToggle = true
 # Series see also post count
 maxSeeAlsoItems = 5
 # Custom CSS
-customCSS = ["css/css_dark_mode_gist_embed_code.css"]
+customCSS = ["css/css_dark_mode_gist_embed_code.css", "css/code-blocks.css"]
 # Custom SCSS, file path is relative to Hugo's asset folder (default: {your project root}/assets)
 customSCSS = []
 
 # Custom JS
-customJS = []
+customJS = ["js/copy-code.js"]
 
 # Custom remote JS files
 customRemoteJS = []


### PR DESCRIPTION
## What

Add a language label header bar and copy-to-clipboard button to all syntax-highlighted code blocks, and enable line numbers site-wide.

## Why

Improve the code reading and sharing experience for blog visitors by making it easy to identify the language and copy code snippets without manually selecting text.

## Notes

- Copy button uses Clipboard API with `document.execCommand` fallback for non-HTTPS contexts
- Line numbers use table mode so they are excluded from copied text
- JS handles edge cases: missing language, duplicate init, inline line number stripping
- CSS uses child combinators (`>`) to avoid specificity conflicts with theme styles
- Hardcoded dark-mode colors in `code-blocks.css` — will need updating if light mode is ever re-enabled

## Testing

- Verified Hugo builds cleanly with no errors
- Manually previewed via `hugo server -D` — code blocks render with language header, copy button, and line numbers
- Tested copy button on code blocks with and without language specifiers
- Confirmed horizontal scroll still works on wide code blocks (no `overflow: hidden` clipping)