### PR TITLE
ci: add harden-runner to all workflows and mark-ready-when-ready workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,14 +20,19 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag v6.0.2
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # tag v3.0.0
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: "latest"
           extended: true
@@ -33,7 +41,7 @@ jobs:
         run: hugo --minify
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # tag v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -11,6 +11,9 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,7 +22,12 @@ jobs:
   htmltest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag v6.0.2
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           fetch-depth: 0
@@ -27,12 +35,12 @@ jobs:
 
       - name: Get changed posts
         id: changed-posts
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # tag v47.0.5
+        uses: step-security/changed-files@60967b822d3001fa82242f8d6b4ed46bc3600a68 # v47.0.1
         with:
           files: content/posts/**
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # tag v3.0.0
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: "latest"
           extended: true

--- a/.github/workflows/mark-ready-when-ready.yml
+++ b/.github/workflows/mark-ready-when-ready.yml
@@ -23,7 +23,8 @@ jobs:
       statuses: read
     if: |
       contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
-      github.event.pull_request.draft == true
+      github.event.pull_request.draft == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1

--- a/.github/workflows/mark-ready-when-ready.yml
+++ b/.github/workflows/mark-ready-when-ready.yml
@@ -1,0 +1,36 @@
+---
+name: Mark PR Ready When Ready
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  mark-ready:
+    name: Mark as ready after successful checks
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+      statuses: read
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
+      github.event.pull_request.draft == true
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Mark ready when ready
+        uses: kenyonj/mark-ready-when-ready@2516fce4e0e647294e1025fcdb73ee492fac654b # v1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -24,10 +24,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag v6.0.2
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # tag v23.0.0
+      - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
         with:
           globs: "content/**/*.md"

--- a/.github/workflows/security-insights.yml
+++ b/.github/workflows/security-insights.yml
@@ -20,11 +20,16 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Validate Security Insights
-        uses: revanite-io/security-insights-action@85c35a5b75f2772e0462323d7b4fcbab5fc1aff2
+        uses: revanite-io/security-insights-action@85c35a5b75f2772e0462323d7b4fcbab5fc1aff2 # v1.0.0
         with:
           file: .github/security-insights.yml


### PR DESCRIPTION
## What

Add step-security/harden-runner as the first step in every workflow job, add a new mark-ready-when-ready workflow, replace tj-actions/changed-files with step-security/changed-files, pin all action refs to full SHAs, and add top-level permissions blocks where missing.

## Why

Harden the CI supply chain by auditing egress traffic, enforcing least-privilege permissions, and ensuring all action references use immutable SHA pins rather than mutable tags.

## Notes

- harden-runner uses `egress-policy: audit` (monitor only) — switch to `egress-policy: block` after reviewing StepSecurity dashboard to avoid breaking workflows
- mark-ready-when-ready requires a "Mark Ready When Ready" label to exist in the repo and only acts on draft PRs
- `step-security/changed-files` is a maintained fork of `tj-actions/changed-files`; v47.0.1 vs the previous v47.0.5 — verify the htmltest workflow still detects changed posts correctly
- `security-insights.yml` previously used unpinned `actions/checkout@v6` — now pinned to the same SHA as all other workflows

## Testing

- Verified all action SHA pins match their stated version tags via GitHub API
- Workflow YAML syntax validated (no structural changes beyond adding steps and permissions)
- mark-ready-when-ready workflow only triggers on PRs with the "Mark Ready When Ready" label, so it's inert until the label is created