### PR TITLE
fix: code block styling — gap, rounded corners, and state class cleanup

### DIFF
--- a/assets/css/code-blocks.css
+++ b/assets/css/code-blocks.css
@@ -11,9 +11,10 @@
   border-radius: 0;
 }
 
-/* Clip top corners via header, allow horizontal scroll on code */
-.highlight > pre,
-.highlight > div > pre {
+/* Reset nested margins/padding and allow horizontal scroll on code */
+.highlight pre {
+  margin: 0;
+  padding: 0.5rem 1rem;
   overflow-x: auto;
 }
 
@@ -25,6 +26,7 @@
   padding: 0.4rem 1rem;
   background-color: #1a1a2e;
   border-bottom: 1px solid #2a2a3e;
+  border-radius: 0.8rem 0.8rem 0 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 1.2rem;
   user-select: none;

--- a/assets/css/code-blocks.css
+++ b/assets/css/code-blocks.css
@@ -11,8 +11,9 @@
   border-radius: 0;
 }
 
-/* Reset nested margins/padding and allow horizontal scroll on code */
-.highlight pre {
+/* Reset nested margins/padding and allow horizontal scroll on code.
+   Scope to Chroma blocks to avoid affecting GitHub Gist embeds. */
+.highlight .chroma pre {
   margin: 0;
   padding: 0.5rem 1rem;
   overflow-x: auto;

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -58,11 +58,22 @@
     if (button._copyStateTimeoutId) {
       clearTimeout(button._copyStateTimeoutId);
     }
+    if (button._copyStateClassName && button._copyStateClassName !== className) {
+      button.classList.remove(button._copyStateClassName);
+    }
     button.textContent = text;
-    if (className) button.classList.add(className);
+    if (className) {
+      button.classList.add(className);
+      button._copyStateClassName = className;
+    } else {
+      button._copyStateClassName = null;
+    }
     button._copyStateTimeoutId = setTimeout(function () {
       button.textContent = "Copy";
-      if (className) button.classList.remove(className);
+      if (button._copyStateClassName) {
+        button.classList.remove(button._copyStateClassName);
+        button._copyStateClassName = null;
+      }
       button._copyStateTimeoutId = null;
     }, duration || 2000);
   }


### PR DESCRIPTION
## What

Fix three post-merge issues from PR #47: remove gap between code header and code content, add rounded top corners to the header bar, and properly clear previous button state classes on rapid clicks.

## Why

The theme's nested `pre` margins created a visible gap below the header bar, the header background rendered with square corners against the rounded `.highlight` container, and rapid copy button state transitions could leave stale CSS classes.

## Notes

- Pre selector broadened from `.highlight > pre` to `.highlight pre` to catch the `table > td > pre` nesting that line numbers create
- Header gets `border-radius: 0.8rem 0.8rem 0 0` matching the parent container
- Button state tracking now stores the active class name and clears it before applying a new one
- Addresses post-merge Copilot review comments on PR #47

## Testing

- Verified Hugo builds cleanly
- Manually previewed code blocks on posts with code (e.g., ruby-design-patterns) — no gap, rounded corners visible, copy button works