### PR TITLE
fix: eliminate gap between code block header and body

### DIFF
--- a/assets/css/code-blocks.css
+++ b/assets/css/code-blocks.css
@@ -20,10 +20,11 @@
 }
 
 /* Header bar with language label and copy button */
-.code-header {
+.highlight > .code-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin: 0;
   padding: 0.4rem 1rem;
   background-color: #1a1a2e;
   border-bottom: 1px solid #2a2a3e;


### PR DESCRIPTION
## What

Override the theme's `.highlight div` margin on the `.code-header` element by increasing selector specificity to `.highlight > .code-header` and setting `margin: 0`.

## Why

The theme's `_base.scss` applies `margin: 2rem 0` to all divs inside `.highlight`. The JS-injected `.code-header` div matched that rule at higher specificity (0,1,1) than the existing `.code-header` selector (0,1,0), causing a visible gap between the language/copy header bar and the code body.

## Notes

- The fix uses a child combinator (`>`) to both increase specificity and be precise about which element is targeted

## Testing

- Verified locally by loading a post with code blocks (`/posts/ruby-design-patterns-by-russ-olsen/`) and confirming the gap between the header bar and code body is eliminated
- Hugo build (`hugo --minify`) completes with no errors