### PR TITLE
ci: add auto-labeler, PR title linting, and stale issue workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,76 @@
+---
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  # Changelog
+  $CHANGES
+
+  See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    labels:
+      - "infrastructure"
+      - "automation"
+      - "documentation"
+      - "dependencies"
+      - "maintenance"
+      - "revert"
+  - title: "🏎 Performance"
+    labels:
+      - "performance"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+      - "major"
+  minor:
+    labels:
+      - "enhancement"
+      - "feature"
+      - "minor"
+  patch:
+    labels:
+      - "documentation"
+      - "fix"
+      - "maintenance"
+      - "patch"
+  default: patch
+autolabeler:
+  - label: "automation"
+    title:
+      - "/^(build|ci|refactor|test).*/i"
+  - label: "performance"
+    title:
+      - "/^(perf).*/i"
+  - label: "enhancement"
+    title:
+      - "/^(style).*/i"
+  - label: "documentation"
+    title:
+      - "/^(docs).*/i"
+  - label: "feature"
+    title:
+      - "/^(feat).*/i"
+  - label: "fix"
+    title:
+      - "/^(fix).*/i"
+  - label: "infrastructure"
+    title:
+      - "/^(infrastructure).*/i"
+  - label: "maintenance"
+    title:
+      - "/^(chore|maintenance).*/i"
+  - label: "revert"
+    title:
+      - "/^(revert).*/i"

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -1,0 +1,17 @@
+---
+name: Auto Labeler
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+permissions:
+  contents: read
+jobs:
+  main:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    with:
+      config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,17 @@
+## Reference: https://github.com/amannn/action-semantic-pull-request
+---
+name: "Lint PR Title"
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+permissions:
+  contents: read
+jobs:
+  main:
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,28 @@
+name: "Close stale issues"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          stale-issue-message: "This issue is stale because it has been open 21 days with no activity. Remove stale label or comment or this will be closed in 14 days."
+          close-issue-message: "This issue was closed because it has been stalled for 35 days with no activity."
+          days-before-stale: 21
+          days-before-close: 14
+          days-before-pr-close: -1
+          exempt-issue-labels: keep

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ run:
 
 lint:
     markdownlint-cli2 "content/**/*.md" --fix
+    actionlint
 
 htmltest:
     htmltest -c .htmltest.yml


### PR DESCRIPTION
## What

Add three new GitHub Actions workflows (auto-labeler, PR title linting, stale issue cleanup) and a release-drafter config that drives both auto-labeling and release note generation. Add actionlint to the justfile lint target for local workflow validation.

## Why

Automate PR hygiene — enforce conventional commit titles, apply labels based on title prefixes, generate categorized release notes, and close stale issues after 35 days of inactivity. Including actionlint in the lint target catches workflow syntax issues before they hit CI.

## Notes

- Auto-labeler and release-drafter share the same config (`.github/release-drafter.yml`) to keep label definitions in one place
- Stale workflow only closes issues, not PRs (`days-before-pr-close: -1`)
- All third-party action refs are pinned to full SHAs
- Auto-labeler and PR title lint reuse the same `ospo-reusable-workflows` SHA

## Testing

- Ran `actionlint` locally against all workflow files — no errors