### PR TITLE
ci: harden GHA workflows with least-privilege permissions, concurrency, and action updates

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -3,13 +3,18 @@ name: Auto Labeler
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
-permissions:
-  contents: read
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # Required by reusable workflow
+      pull-requests: write # Apply labels to PRs
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@6d7a83e6fc8275128984b0ed3defa4b8cdc40f85
     with:
       config-name: release-drafter.yml

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -7,17 +7,16 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
     permissions:
-      contents: write
+      contents: write # Push to gh-pages branch
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
@@ -25,7 +24,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -11,15 +11,16 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   htmltest:
+    permissions:
+      contents: read # Clone the repository
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
@@ -27,7 +28,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/mark-ready-when-ready.yaml
+++ b/.github/workflows/mark-ready-when-ready.yaml
@@ -5,11 +5,10 @@ on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize]
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,10 +16,10 @@ jobs:
     name: Mark as ready after successful checks
     runs-on: ubuntu-latest
     permissions:
-      checks: read
-      contents: write
-      pull-requests: write
-      statuses: read
+      checks: read # Read check suite results
+      contents: write # Update PR branch
+      pull-requests: write # Mark PR as ready for review
+      statuses: read # Read commit statuses
     if: |
       contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
       github.event.pull_request.draft == true &&

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -13,15 +13,16 @@ on:
     paths:
       - "content/**/*.md"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+permissions: {}
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:
+    permissions:
+      contents: read # Clone the repository
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
@@ -29,7 +30,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/osps-security-assessment.yaml
+++ b/.github/workflows/osps-security-assessment.yaml
@@ -6,19 +6,26 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch: # Allow manual triggering
 
+permissions: {}
+
 jobs:
   osps-assessment:
     runs-on: ubuntu-latest
     name: OSPS Security Assessment
 
     permissions:
-      contents: read
-      id-token: write
-      security-events: write # Required for SARIF upload
+      contents: read # Clone the repository
+      id-token: write # Federate via octo-sts
+      security-events: write # Upload SARIF results
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -29,7 +36,7 @@ jobs:
           identity: jmeridth.github.io
 
       - name: Open Source Project Security Baseline Scanner
-        uses: revanite-io/osps-baseline-action@ace75cc1fb748be898275f16f59f78363405bc0a
+        uses: revanite-io/osps-baseline-action@ace75cc1fb748be898275f16f59f78363405bc0a # v1.3.3
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
@@ -39,7 +46,7 @@ jobs:
 
       - name: Upload Assessment Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: osps-assessment-results-${{ github.run_number }}
           path: evaluation_results/

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -4,14 +4,19 @@ name: "Lint PR Title"
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
-permissions:
-  contents: read
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     permissions:
-      contents: read
-      pull-requests: read
-      statuses: write
+      contents: read # Required by reusable workflow
+      pull-requests: read # Read PR title
+      statuses: write # Report lint status
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@6d7a83e6fc8275128984b0ed3defa4b8cdc40f85
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-insights.yaml
+++ b/.github/workflows/security-insights.yaml
@@ -13,11 +13,16 @@ on:
     paths:
       - ".github/security-insights.yml"
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:
+    permissions:
+      contents: read # Clone the repository
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
@@ -25,7 +30,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,15 +3,14 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: read
+      issues: write # Label and close stale issues
+      pull-requests: read # Check PR activity
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## What/Why

Apply GHA security and operational standards across all 9 workflows: least-privilege permissions (`permissions: {}`at workflow level, explicit job-level grants with comments), proper concurrency groups (`github.head_ref || github.ref`), SHA-pinned actions, harden-runner coverage, and `.yaml` extension consistency.

## Proof it works

`actionlint` passes with zero errors on all 9 workflow files.

## Risk + AI role

low -- CI-only changes, no application code affected. AI-generated (Claude Opus 4.6). `actions/checkout` v6 to v7 is the largest change; v7 blocks fork PR checkouts on `pull_request_target` and `workflow_run` triggers, which does not affect these workflows.

## Review focus

- `actions/checkout` v7 upgrade: confirm no workflow relies on checking out fork PR code via `workflow_run`
- Concurrency groups: verify `cancel-in-progress` conditions match each workflow's trigger mix